### PR TITLE
Add Bilig WorkPaper MCP to ecosystem

### DIFF
--- a/data/ecosystem-tools.yaml
+++ b/data/ecosystem-tools.yaml
@@ -550,3 +550,16 @@ tools:
     license: "MIT"
     language: "Python"
     tags: ["evaluation", "benchmarking", "adversarial", "microsoft", "python"]
+
+  - name: "Bilig WorkPaper MCP"
+    slug: "bilig-workpaper-mcp"
+    description: "Formula WorkPaper runtime for agents: edit cells, recalculate formulas, verify readback, and persist JSON."
+    category: "mcp-servers"
+    homepage: "https://proompteng.github.io/bilig/"
+    repo: "https://github.com/proompteng/bilig"
+    license: "MIT"
+    language: "TypeScript"
+    open_source: true
+    tags: ["mcp", "spreadsheet", "formula-engine", "agents", "typescript", "workpaper"]
+    install:
+      npm: "npm exec --package @bilig/headless -- bilig-workpaper-mcp"


### PR DESCRIPTION
Adds Bilig WorkPaper MCP to the AI-native ecosystem directory under MCP servers.

Bilig is an open-source TypeScript Formula WorkPaper runtime for agent and backend workflows: agents can edit cells through an API, recalculate formulas, verify readback, and persist JSON without driving Excel, Google Sheets, or screenshots.

Links:
- Repo: https://github.com/proompteng/bilig
- Docs: https://proompteng.github.io/bilig/
- npm: https://www.npmjs.com/package/@bilig/workpaper

Install:
```bash
npm exec --package @bilig/workpaper -- bilig-workpaper-mcp
```
