### PR TITLE
Add AI Agent Security Mini-Audit to ecosystem

### DIFF
--- a/data/ecosystem-tools.yaml
+++ b/data/ecosystem-tools.yaml
@@ -550,3 +550,12 @@ tools:
     license: "MIT"
     language: "Python"
     tags: ["evaluation", "benchmarking", "adversarial", "microsoft", "python"]
+  - name: "AI Agent Security Mini-Audit"
+    slug: "ai-agent-security-mini-audit"
+    description: "Browser-first checks for AI agent, contact funnel, and handoff risk."
+    category: "evaluation"
+    homepage: "https://mauroceron.github.io/ai-agent-security-mini-audit/"
+    repo: "https://github.com/MAUROCERON/ai-agent-security-mini-audit"
+    license: "MIT"
+    language: "HTML"
+    tags: ["ai-safety", "evaluation", "agents", "qa", "local-first", "security"]


### PR DESCRIPTION
Adds AI Agent Security Mini-Audit as an open-source evaluation tool.

Why it fits:
- Browser-first checks for AI agent launch risk, contact funnels, and handoff QA.
- Public homepage and MIT-licensed GitHub repo.
- Local/static pages with free self-check workflows.

Category: evaluation